### PR TITLE
Corrected typo error in rending.html 'max-content'

### DIFF
--- a/rendering.html
+++ b/rendering.html
@@ -160,7 +160,7 @@
     2. If the value for width is greater than the value for max-width, then max-width overrides width.-->
 
     <!-- min-content(element children with line breaking) -->
-    <!-- min-content(smallest value that contains the content, without breaking it up) -->
+    <!-- max-content(smallest value that contains the content, without breaking it up) -->
     <!-- fit-content(combine min and max with line break as need never exceed available space) -->
 
     <!-- min-width -->


### PR DESCRIPTION
I noticed a typographical error in the rendering.html file, line 163.
The definition for max-content.
I corrected it from min-content to 'max-content'

 